### PR TITLE
Making the user data fields mapping to Shibboleth variables configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ To use OmniAuth Shibboleth strategy as a middleware in your rails application, a
       provider :shibboleth, {
         :shib_session_id_field     => "Shib-Session-ID",
         :shib_application_id_field => "Shib-Application-ID",
-        :uid_field                 => "uid",
-        :name_field                => "displayName",
-        :email_field               => "mail",
         :debug                     => false,
         :extra_fields => [
           :"unscoped-affiliation",
@@ -59,8 +56,14 @@ These can be changed by :uid_field and :fields option.
     % vi config/initializer/omniauth.rb
     Rails.application.config.middleware.use OmniAuth::Builder do
       provider :shibboleth, {
-        :uid_field => :uid,
-        :fields => []
+        :uid_field                 => "uid",
+        :name_field                => "displayName",
+        :email_field               => "mail",
+        :fields => {
+          :location => "contactAddress",
+          :image    => "photo_url",
+          :phone    => "contactPhone",
+        }
       }
     end
 

--- a/lib/omniauth/strategies/shibboleth.rb
+++ b/lib/omniauth/strategies/shibboleth.rb
@@ -8,6 +8,7 @@ module OmniAuth
       option :uid_field, 'eppn'
       option :name_field, 'displayName'
       option :email_field, 'mail'
+      option :fields, {}
       option :extra_fields, []
       option :debug, false
 
@@ -42,11 +43,15 @@ module OmniAuth
       end
 
       info do
-        {
+        res = {
           :uid   => request.env[options.uid_field.to_s],
           :name  => request.env[options.name_field.to_s],
           :email => request.env[options.email_field.to_s],
         }
+        options.fields.each_pair do |k,v|
+          res[k] = request.env[v.to_s]
+        end
+        res
       end
 
       extra do

--- a/spec/omniauth/strategies/shibboleth_spec.rb
+++ b/spec/omniauth/strategies/shibboleth_spec.rb
@@ -69,6 +69,7 @@ describe OmniAuth::Strategies::Shibboleth do
         :uid_field => :eppn,
         :name_field => :displayName,
         :email_field => :mail,
+	:fields => {},
         :extra_fields => [:o, :affiliation] } }
       let(:app){ lambda{|env| [404, {}, ['Awesome']]}}
       let(:strategy){ OmniAuth::Strategies::Shibboleth.new(app, options) }


### PR DESCRIPTION
Hello!

I had to integrate an OSQA installation with our corporate Shibboleth authentication service and I used your module. Doing so I had to change the module's code to adjust the environment variable names, to suit my case. At the end I made these environment variable names configurable and this is the result.

I am not sure the changes in file "spec/omniauth/strategies/shibboleth_spec.rb" are correct, sorry about that. But the code I send you here is working fine for me and should work for everyone else.

I tried to keep compatibility with previous version by setting the default values of the new configuration variables to the old hardcoded values, except for the variable "uid_field" which was moved into the variable "fields" hash with key name "uid".

I have also changed the "README.md" to include an example for the new configuration.

Best regards.
Tiago
